### PR TITLE
all pad-variant footprints use the base model

### DIFF
--- a/DIP-10_W10.16mm_LongPads.kicad_mod
+++ b/DIP-10_W10.16mm_LongPads.kicad_mod
@@ -35,7 +35,7 @@
   (fp_text user %R (at 5.08 5.08) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-10_W10.16mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-10_W10.16mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-10_W7.62mm_LongPads.kicad_mod
+++ b/DIP-10_W7.62mm_LongPads.kicad_mod
@@ -35,7 +35,7 @@
   (fp_text user %R (at 3.81 5.08) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-10_W7.62mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-10_W7.62mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-10_W7.62mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-10_W7.62mm_SMDSocket_SmallPads.kicad_mod
@@ -44,7 +44,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-10_W7.62mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-10_W7.62mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-10_W7.62mm_Socket_LongPads.kicad_mod
+++ b/DIP-10_W7.62mm_Socket_LongPads.kicad_mod
@@ -43,7 +43,7 @@
   (fp_text user %R (at 3.81 5.08) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-10_W7.62mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-10_W7.62mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-10_W8.89mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-10_W8.89mm_SMDSocket_LongPads.kicad_mod
@@ -44,7 +44,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-10_W8.89mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-10_W8.89mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-12_W10.16mm_LongPads.kicad_mod
+++ b/DIP-12_W10.16mm_LongPads.kicad_mod
@@ -37,7 +37,7 @@
   (fp_text user %R (at 5.08 6.35) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-12_W10.16mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-12_W10.16mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-12_W7.62mm_LongPads.kicad_mod
+++ b/DIP-12_W7.62mm_LongPads.kicad_mod
@@ -37,7 +37,7 @@
   (fp_text user %R (at 3.81 6.35) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-12_W7.62mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-12_W7.62mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-12_W7.62mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-12_W7.62mm_SMDSocket_SmallPads.kicad_mod
@@ -46,7 +46,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-12_W7.62mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-12_W7.62mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-12_W7.62mm_Socket_LongPads.kicad_mod
+++ b/DIP-12_W7.62mm_Socket_LongPads.kicad_mod
@@ -45,7 +45,7 @@
   (fp_text user %R (at 3.81 6.35) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-12_W7.62mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-12_W7.62mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-12_W8.89mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-12_W8.89mm_SMDSocket_LongPads.kicad_mod
@@ -46,7 +46,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-12_W8.89mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-12_W8.89mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-14_W10.16mm_LongPads.kicad_mod
+++ b/DIP-14_W10.16mm_LongPads.kicad_mod
@@ -39,7 +39,7 @@
   (fp_text user %R (at 5.08 7.62) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-14_W10.16mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-14_W10.16mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-14_W7.62mm_LongPads.kicad_mod
+++ b/DIP-14_W7.62mm_LongPads.kicad_mod
@@ -39,7 +39,7 @@
   (fp_text user %R (at 3.81 7.62) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-14_W7.62mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-14_W7.62mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-14_W7.62mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-14_W7.62mm_SMDSocket_SmallPads.kicad_mod
@@ -48,7 +48,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-14_W7.62mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-14_W7.62mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-14_W7.62mm_Socket_LongPads.kicad_mod
+++ b/DIP-14_W7.62mm_Socket_LongPads.kicad_mod
@@ -47,7 +47,7 @@
   (fp_text user %R (at 3.81 7.62) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-14_W7.62mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-14_W7.62mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-14_W8.89mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-14_W8.89mm_SMDSocket_LongPads.kicad_mod
@@ -48,7 +48,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-14_W8.89mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-14_W8.89mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-16_W10.16mm_LongPads.kicad_mod
+++ b/DIP-16_W10.16mm_LongPads.kicad_mod
@@ -41,7 +41,7 @@
   (fp_text user %R (at 5.08 8.89) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-16_W10.16mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-16_W10.16mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-16_W7.62mm_LongPads.kicad_mod
+++ b/DIP-16_W7.62mm_LongPads.kicad_mod
@@ -41,7 +41,7 @@
   (fp_text user %R (at 3.81 8.89) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-16_W7.62mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-16_W7.62mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-16_W7.62mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-16_W7.62mm_SMDSocket_SmallPads.kicad_mod
@@ -50,7 +50,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-16_W7.62mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-16_W7.62mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-16_W7.62mm_Socket_LongPads.kicad_mod
+++ b/DIP-16_W7.62mm_Socket_LongPads.kicad_mod
@@ -49,7 +49,7 @@
   (fp_text user %R (at 3.81 8.89) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-16_W7.62mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-16_W7.62mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-16_W8.89mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-16_W8.89mm_SMDSocket_LongPads.kicad_mod
@@ -50,7 +50,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-16_W8.89mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-16_W8.89mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-18_W7.62mm_LongPads.kicad_mod
+++ b/DIP-18_W7.62mm_LongPads.kicad_mod
@@ -43,7 +43,7 @@
   (fp_text user %R (at 3.81 10.16) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-18_W7.62mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-18_W7.62mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-18_W7.62mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-18_W7.62mm_SMDSocket_SmallPads.kicad_mod
@@ -52,7 +52,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-18_W7.62mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-18_W7.62mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-18_W7.62mm_Socket_LongPads.kicad_mod
+++ b/DIP-18_W7.62mm_Socket_LongPads.kicad_mod
@@ -51,7 +51,7 @@
   (fp_text user %R (at 3.81 10.16) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-18_W7.62mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-18_W7.62mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-18_W8.89mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-18_W8.89mm_SMDSocket_LongPads.kicad_mod
@@ -52,7 +52,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-18_W8.89mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-18_W8.89mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-20_W7.62mm_LongPads.kicad_mod
+++ b/DIP-20_W7.62mm_LongPads.kicad_mod
@@ -45,7 +45,7 @@
   (fp_text user %R (at 3.81 11.43) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-20_W7.62mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-20_W7.62mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-20_W7.62mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-20_W7.62mm_SMDSocket_SmallPads.kicad_mod
@@ -54,7 +54,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-20_W7.62mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-20_W7.62mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-20_W7.62mm_Socket_LongPads.kicad_mod
+++ b/DIP-20_W7.62mm_Socket_LongPads.kicad_mod
@@ -53,7 +53,7 @@
   (fp_text user %R (at 3.81 11.43) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-20_W7.62mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-20_W7.62mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-20_W8.89mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-20_W8.89mm_SMDSocket_LongPads.kicad_mod
@@ -54,7 +54,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-20_W8.89mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-20_W8.89mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-22_W10.16mm_LongPads.kicad_mod
+++ b/DIP-22_W10.16mm_LongPads.kicad_mod
@@ -47,7 +47,7 @@
   (fp_text user %R (at 5.08 12.7) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W10.16mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W10.16mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-22_W10.16mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-22_W10.16mm_SMDSocket_SmallPads.kicad_mod
@@ -56,7 +56,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W10.16mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W10.16mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-22_W10.16mm_Socket_LongPads.kicad_mod
+++ b/DIP-22_W10.16mm_Socket_LongPads.kicad_mod
@@ -55,7 +55,7 @@
   (fp_text user %R (at 5.08 12.7) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W10.16mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W10.16mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-22_W11.43mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-22_W11.43mm_SMDSocket_LongPads.kicad_mod
@@ -56,7 +56,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W11.43mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W11.43mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-22_W7.62mm_LongPads.kicad_mod
+++ b/DIP-22_W7.62mm_LongPads.kicad_mod
@@ -47,7 +47,7 @@
   (fp_text user %R (at 3.81 12.7) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W7.62mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W7.62mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-22_W7.62mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-22_W7.62mm_SMDSocket_SmallPads.kicad_mod
@@ -56,7 +56,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W7.62mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W7.62mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-22_W7.62mm_Socket_LongPads.kicad_mod
+++ b/DIP-22_W7.62mm_Socket_LongPads.kicad_mod
@@ -55,7 +55,7 @@
   (fp_text user %R (at 3.81 12.7) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W7.62mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W7.62mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-22_W8.89mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-22_W8.89mm_SMDSocket_LongPads.kicad_mod
@@ -56,7 +56,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W8.89mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-22_W8.89mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-24_W10.16mm_LongPads.kicad_mod
+++ b/DIP-24_W10.16mm_LongPads.kicad_mod
@@ -49,7 +49,7 @@
   (fp_text user %R (at 5.08 13.97) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W10.16mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W10.16mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-24_W10.16mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-24_W10.16mm_SMDSocket_SmallPads.kicad_mod
@@ -58,7 +58,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W10.16mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W10.16mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-24_W10.16mm_Socket_LongPads.kicad_mod
+++ b/DIP-24_W10.16mm_Socket_LongPads.kicad_mod
@@ -57,7 +57,7 @@
   (fp_text user %R (at 5.08 13.97) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W10.16mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W10.16mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-24_W11.43mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-24_W11.43mm_SMDSocket_LongPads.kicad_mod
@@ -58,7 +58,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W11.43mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W11.43mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-24_W15.24mm_LongPads.kicad_mod
+++ b/DIP-24_W15.24mm_LongPads.kicad_mod
@@ -49,7 +49,7 @@
   (fp_text user %R (at 7.62 13.97) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W15.24mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W15.24mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-24_W15.24mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-24_W15.24mm_SMDSocket_SmallPads.kicad_mod
@@ -58,7 +58,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W15.24mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W15.24mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-24_W15.24mm_Socket_LongPads.kicad_mod
+++ b/DIP-24_W15.24mm_Socket_LongPads.kicad_mod
@@ -57,7 +57,7 @@
   (fp_text user %R (at 7.62 13.97) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W15.24mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W15.24mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-24_W16.51mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-24_W16.51mm_SMDSocket_LongPads.kicad_mod
@@ -58,7 +58,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W16.51mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W16.51mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-24_W7.62mm_LongPads.kicad_mod
+++ b/DIP-24_W7.62mm_LongPads.kicad_mod
@@ -49,7 +49,7 @@
   (fp_text user %R (at 3.81 13.97) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W7.62mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W7.62mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-24_W7.62mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-24_W7.62mm_SMDSocket_SmallPads.kicad_mod
@@ -58,7 +58,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W7.62mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W7.62mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-24_W7.62mm_Socket_LongPads.kicad_mod
+++ b/DIP-24_W7.62mm_Socket_LongPads.kicad_mod
@@ -57,7 +57,7 @@
   (fp_text user %R (at 3.81 13.97) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W7.62mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W7.62mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-24_W8.89mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-24_W8.89mm_SMDSocket_LongPads.kicad_mod
@@ -58,7 +58,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W8.89mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-24_W8.89mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-28_W15.24mm_LongPads.kicad_mod
+++ b/DIP-28_W15.24mm_LongPads.kicad_mod
@@ -53,7 +53,7 @@
   (fp_text user %R (at 7.62 16.51) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W15.24mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W15.24mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-28_W15.24mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-28_W15.24mm_SMDSocket_SmallPads.kicad_mod
@@ -62,7 +62,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W15.24mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W15.24mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-28_W15.24mm_Socket_LongPads.kicad_mod
+++ b/DIP-28_W15.24mm_Socket_LongPads.kicad_mod
@@ -61,7 +61,7 @@
   (fp_text user %R (at 7.62 16.51) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W15.24mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W15.24mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-28_W16.51mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-28_W16.51mm_SMDSocket_LongPads.kicad_mod
@@ -62,7 +62,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W16.51mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W16.51mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-28_W7.62mm_LongPads.kicad_mod
+++ b/DIP-28_W7.62mm_LongPads.kicad_mod
@@ -53,7 +53,7 @@
   (fp_text user %R (at 3.81 16.51) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W7.62mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W7.62mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-28_W7.62mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-28_W7.62mm_SMDSocket_SmallPads.kicad_mod
@@ -62,7 +62,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W7.62mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W7.62mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-28_W7.62mm_Socket_LongPads.kicad_mod
+++ b/DIP-28_W7.62mm_Socket_LongPads.kicad_mod
@@ -61,7 +61,7 @@
   (fp_text user %R (at 3.81 16.51) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W7.62mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W7.62mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-28_W8.89mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-28_W8.89mm_SMDSocket_LongPads.kicad_mod
@@ -62,7 +62,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W8.89mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-28_W8.89mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-32_W15.24mm_LongPads.kicad_mod
+++ b/DIP-32_W15.24mm_LongPads.kicad_mod
@@ -57,7 +57,7 @@
   (fp_text user %R (at 7.62 19.05) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-32_W15.24mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-32_W15.24mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-32_W15.24mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-32_W15.24mm_SMDSocket_SmallPads.kicad_mod
@@ -66,7 +66,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-32_W15.24mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-32_W15.24mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-32_W15.24mm_Socket_LongPads.kicad_mod
+++ b/DIP-32_W15.24mm_Socket_LongPads.kicad_mod
@@ -65,7 +65,7 @@
   (fp_text user %R (at 7.62 19.05) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-32_W15.24mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-32_W15.24mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-32_W16.51mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-32_W16.51mm_SMDSocket_LongPads.kicad_mod
@@ -66,7 +66,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-32_W16.51mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-32_W16.51mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-40_W15.24mm_LongPads.kicad_mod
+++ b/DIP-40_W15.24mm_LongPads.kicad_mod
@@ -65,7 +65,7 @@
   (fp_text user %R (at 7.62 24.13) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W15.24mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W15.24mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-40_W15.24mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-40_W15.24mm_SMDSocket_SmallPads.kicad_mod
@@ -74,7 +74,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W15.24mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W15.24mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-40_W15.24mm_Socket_LongPads.kicad_mod
+++ b/DIP-40_W15.24mm_Socket_LongPads.kicad_mod
@@ -73,7 +73,7 @@
   (fp_text user %R (at 7.62 24.13) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W15.24mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W15.24mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-40_W16.51mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-40_W16.51mm_SMDSocket_LongPads.kicad_mod
@@ -74,7 +74,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W16.51mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W16.51mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-40_W25.4mm_LongPads.kicad_mod
+++ b/DIP-40_W25.4mm_LongPads.kicad_mod
@@ -65,7 +65,7 @@
   (fp_text user %R (at 12.7 24.13) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W25.4mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W25.4mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-40_W25.4mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-40_W25.4mm_SMDSocket_SmallPads.kicad_mod
@@ -74,7 +74,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W25.4mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W25.4mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-40_W25.4mm_Socket_LongPads.kicad_mod
+++ b/DIP-40_W25.4mm_Socket_LongPads.kicad_mod
@@ -73,7 +73,7 @@
   (fp_text user %R (at 12.7 24.13) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W25.4mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W25.4mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-40_W26.67mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-40_W26.67mm_SMDSocket_LongPads.kicad_mod
@@ -74,7 +74,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W26.67mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-40_W26.67mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-42_W15.24mm_LongPads.kicad_mod
+++ b/DIP-42_W15.24mm_LongPads.kicad_mod
@@ -67,7 +67,7 @@
   (fp_text user %R (at 7.62 25.4) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-42_W15.24mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-42_W15.24mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-42_W15.24mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-42_W15.24mm_SMDSocket_SmallPads.kicad_mod
@@ -76,7 +76,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-42_W15.24mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-42_W15.24mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-42_W15.24mm_Socket_LongPads.kicad_mod
+++ b/DIP-42_W15.24mm_Socket_LongPads.kicad_mod
@@ -75,7 +75,7 @@
   (fp_text user %R (at 7.62 25.4) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-42_W15.24mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-42_W15.24mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-42_W16.51mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-42_W16.51mm_SMDSocket_LongPads.kicad_mod
@@ -76,7 +76,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-42_W16.51mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-42_W16.51mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-48_W15.24mm_LongPads.kicad_mod
+++ b/DIP-48_W15.24mm_LongPads.kicad_mod
@@ -73,7 +73,7 @@
   (fp_text user %R (at 7.62 29.21) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-48_W15.24mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-48_W15.24mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-48_W15.24mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-48_W15.24mm_SMDSocket_SmallPads.kicad_mod
@@ -82,7 +82,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-48_W15.24mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-48_W15.24mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-48_W15.24mm_Socket_LongPads.kicad_mod
+++ b/DIP-48_W15.24mm_Socket_LongPads.kicad_mod
@@ -81,7 +81,7 @@
   (fp_text user %R (at 7.62 29.21) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-48_W15.24mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-48_W15.24mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-48_W16.51mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-48_W16.51mm_SMDSocket_LongPads.kicad_mod
@@ -82,7 +82,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-48_W16.51mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-48_W16.51mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-4_W10.16mm_LongPads.kicad_mod
+++ b/DIP-4_W10.16mm_LongPads.kicad_mod
@@ -29,7 +29,7 @@
   (fp_text user %R (at 5.08 1.27) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-4_W10.16mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-4_W10.16mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-4_W7.62mm_LongPads.kicad_mod
+++ b/DIP-4_W7.62mm_LongPads.kicad_mod
@@ -29,7 +29,7 @@
   (fp_text user %R (at 3.81 1.27) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-4_W7.62mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-4_W7.62mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-4_W7.62mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-4_W7.62mm_SMDSocket_SmallPads.kicad_mod
@@ -38,7 +38,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-4_W7.62mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-4_W7.62mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-4_W7.62mm_Socket_LongPads.kicad_mod
+++ b/DIP-4_W7.62mm_Socket_LongPads.kicad_mod
@@ -37,7 +37,7 @@
   (fp_text user %R (at 3.81 1.27) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-4_W7.62mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-4_W7.62mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-4_W8.89mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-4_W8.89mm_SMDSocket_LongPads.kicad_mod
@@ -38,7 +38,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-4_W8.89mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-4_W8.89mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-64_W15.24mm_LongPads.kicad_mod
+++ b/DIP-64_W15.24mm_LongPads.kicad_mod
@@ -89,7 +89,7 @@
   (fp_text user %R (at 7.62 39.37) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W15.24mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W15.24mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-64_W15.24mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-64_W15.24mm_SMDSocket_SmallPads.kicad_mod
@@ -98,7 +98,7 @@
   (fp_text user %R (at 0 -0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W15.24mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W15.24mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-64_W15.24mm_Socket_LongPads.kicad_mod
+++ b/DIP-64_W15.24mm_Socket_LongPads.kicad_mod
@@ -97,7 +97,7 @@
   (fp_text user %R (at 7.62 39.37) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W15.24mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W15.24mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-64_W16.51mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-64_W16.51mm_SMDSocket_LongPads.kicad_mod
@@ -98,7 +98,7 @@
   (fp_text user %R (at 0 -0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W16.51mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W16.51mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-64_W22.86mm_LongPads.kicad_mod
+++ b/DIP-64_W22.86mm_LongPads.kicad_mod
@@ -89,7 +89,7 @@
   (fp_text user %R (at 11.43 39.37) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W22.86mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W22.86mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-64_W22.86mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-64_W22.86mm_SMDSocket_SmallPads.kicad_mod
@@ -98,7 +98,7 @@
   (fp_text user %R (at 0 -0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W22.86mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W22.86mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-64_W22.86mm_Socket_LongPads.kicad_mod
+++ b/DIP-64_W22.86mm_Socket_LongPads.kicad_mod
@@ -97,7 +97,7 @@
   (fp_text user %R (at 11.43 39.37) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W22.86mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W22.86mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-64_W24.13mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-64_W24.13mm_SMDSocket_LongPads.kicad_mod
@@ -98,7 +98,7 @@
   (fp_text user %R (at 0 -0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W24.13mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W24.13mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-64_W25.4mm_LongPads.kicad_mod
+++ b/DIP-64_W25.4mm_LongPads.kicad_mod
@@ -89,7 +89,7 @@
   (fp_text user %R (at 12.7 39.37) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W25.4mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W25.4mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-64_W25.4mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-64_W25.4mm_SMDSocket_SmallPads.kicad_mod
@@ -98,7 +98,7 @@
   (fp_text user %R (at 0 -0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W25.4mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W25.4mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-64_W25.4mm_Socket_LongPads.kicad_mod
+++ b/DIP-64_W25.4mm_Socket_LongPads.kicad_mod
@@ -97,7 +97,7 @@
   (fp_text user %R (at 12.7 39.37) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W25.4mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W25.4mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-64_W26.67mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-64_W26.67mm_SMDSocket_LongPads.kicad_mod
@@ -98,7 +98,7 @@
   (fp_text user %R (at 0 -0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W26.67mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-64_W26.67mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-6_W10.16mm_LongPads.kicad_mod
+++ b/DIP-6_W10.16mm_LongPads.kicad_mod
@@ -31,7 +31,7 @@
   (fp_text user %R (at 5.08 2.54) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-6_W10.16mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-6_W10.16mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-6_W7.62mm_LongPads.kicad_mod
+++ b/DIP-6_W7.62mm_LongPads.kicad_mod
@@ -31,7 +31,7 @@
   (fp_text user %R (at 3.81 2.54) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-6_W7.62mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-6_W7.62mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-6_W7.62mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-6_W7.62mm_SMDSocket_SmallPads.kicad_mod
@@ -40,7 +40,7 @@
   (fp_text user %R (at 0 -0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-6_W7.62mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-6_W7.62mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-6_W7.62mm_Socket_LongPads.kicad_mod
+++ b/DIP-6_W7.62mm_Socket_LongPads.kicad_mod
@@ -39,7 +39,7 @@
   (fp_text user %R (at 3.81 2.54) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-6_W7.62mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-6_W7.62mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-6_W8.89mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-6_W8.89mm_SMDSocket_LongPads.kicad_mod
@@ -40,7 +40,7 @@
   (fp_text user %R (at 0 -0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-6_W8.89mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-6_W8.89mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-8_W10.16mm_LongPads.kicad_mod
+++ b/DIP-8_W10.16mm_LongPads.kicad_mod
@@ -33,7 +33,7 @@
   (fp_text user %R (at 5.08 3.81) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-8_W10.16mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-8_W10.16mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-8_W7.62mm_LongPads.kicad_mod
+++ b/DIP-8_W7.62mm_LongPads.kicad_mod
@@ -33,7 +33,7 @@
   (fp_text user %R (at 3.81 3.81) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-8_W7.62mm_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-8_W7.62mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-8_W7.62mm_SMDSocket_SmallPads.kicad_mod
+++ b/DIP-8_W7.62mm_SMDSocket_SmallPads.kicad_mod
@@ -42,7 +42,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-8_W7.62mm_SMDSocket_SmallPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-8_W7.62mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-8_W7.62mm_Socket_LongPads.kicad_mod
+++ b/DIP-8_W7.62mm_Socket_LongPads.kicad_mod
@@ -41,7 +41,7 @@
   (fp_text user %R (at 3.81 3.81) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-8_W7.62mm_Socket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-8_W7.62mm_Socket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/DIP-8_W8.89mm_SMDSocket_LongPads.kicad_mod
+++ b/DIP-8_W8.89mm_SMDSocket_LongPads.kicad_mod
@@ -42,7 +42,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-8_W8.89mm_SMDSocket_LongPads.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/DIP-8_W8.89mm_SMDSocket.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/SMDIP-10_W9.53mm_Clearance8mm.kicad_mod
+++ b/SMDIP-10_W9.53mm_Clearance8mm.kicad_mod
@@ -36,7 +36,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-10_W9.53mm_Clearance8mm.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-10_W9.53mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/SMDIP-12_W9.53mm_Clearance8mm.kicad_mod
+++ b/SMDIP-12_W9.53mm_Clearance8mm.kicad_mod
@@ -38,7 +38,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-12_W9.53mm_Clearance8mm.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-12_W9.53mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/SMDIP-14_W9.53mm_Clearance8mm.kicad_mod
+++ b/SMDIP-14_W9.53mm_Clearance8mm.kicad_mod
@@ -40,7 +40,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-14_W9.53mm_Clearance8mm.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-14_W9.53mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/SMDIP-16_W9.53mm_Clearance8mm.kicad_mod
+++ b/SMDIP-16_W9.53mm_Clearance8mm.kicad_mod
@@ -42,7 +42,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-16_W9.53mm_Clearance8mm.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-16_W9.53mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/SMDIP-18_W9.53mm_Clearance8mm.kicad_mod
+++ b/SMDIP-18_W9.53mm_Clearance8mm.kicad_mod
@@ -44,7 +44,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-18_W9.53mm_Clearance8mm.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-18_W9.53mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/SMDIP-20_W9.53mm_Clearance8mm.kicad_mod
+++ b/SMDIP-20_W9.53mm_Clearance8mm.kicad_mod
@@ -46,7 +46,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-20_W9.53mm_Clearance8mm.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-20_W9.53mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/SMDIP-22_W9.53mm_Clearance8mm.kicad_mod
+++ b/SMDIP-22_W9.53mm_Clearance8mm.kicad_mod
@@ -48,7 +48,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-22_W9.53mm_Clearance8mm.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-22_W9.53mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/SMDIP-4_W9.53mm_Clearance8mm.kicad_mod
+++ b/SMDIP-4_W9.53mm_Clearance8mm.kicad_mod
@@ -30,7 +30,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-4_W9.53mm_Clearance8mm.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-4_W9.53mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/SMDIP-6_W9.53mm_Clearance8mm.kicad_mod
+++ b/SMDIP-6_W9.53mm_Clearance8mm.kicad_mod
@@ -32,7 +32,7 @@
   (fp_text user %R (at 0 -0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-6_W9.53mm_Clearance8mm.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-6_W9.53mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))

--- a/SMDIP-8_W9.53mm_Clearance8mm.kicad_mod
+++ b/SMDIP-8_W9.53mm_Clearance8mm.kicad_mod
@@ -34,7 +34,7 @@
   (fp_text user %R (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-8_W9.53mm_Clearance8mm.wrl
+  (model ${KISYS3DMOD}/Housings_DIP.3dshapes/SMDIP-8_W9.53mm.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
the `_LongPads` and `_SmallPads` and `_Clearance8mm` variants had separate 3D models, which is not necessary. This PR fixes these problems: Now the variant-footprints link the base-model (this causes Travis-errors, which should be ignored in this case!).

@SchrodingersGat @Misca1234 can you have a look?